### PR TITLE
Add 1688 product parser with tests and service integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/parsers/_1688.py
+++ b/parsers/_1688.py
@@ -1,0 +1,59 @@
+import json
+import re
+from typing import Any, Dict
+
+import requests
+
+
+class ParsingError(Exception):
+    """Raised when a product page cannot be parsed."""
+
+
+def _extract_json(html: str) -> Dict[str, Any]:
+    pattern = re.compile(r"window\.__INIT_DATA__\s*=\s*(\{.*?\})\s*;", re.S)
+    match = pattern.search(html)
+    if not match:
+        raise ParsingError("Product data JSON not found")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise ParsingError("Invalid product JSON") from exc
+
+
+def parse_1688_product(url: str) -> Dict[str, Any]:
+    """Fetch and parse product information from 1688.
+
+    Parameters
+    ----------
+    url: str
+        Product page URL.
+
+    Returns
+    -------
+    dict
+        Parsed product data containing name, price, images and delivery info.
+
+    Raises
+    ------
+    ParsingError
+        If the page cannot be retrieved or parsed.
+    """
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise ParsingError(f"Could not fetch {url}") from exc
+
+    data = _extract_json(response.text)
+
+    name = data.get("name") or data.get("title")
+    price = data.get("sku", {}).get("price") or data.get("price")
+    images = data.get("images") or data.get("gallery", [])
+    delivery = data.get("delivery", {})
+
+    return {
+        "name": name,
+        "price": price,
+        "images": images,
+        "delivery": delivery,
+    }

--- a/service.py
+++ b/service.py
@@ -1,0 +1,13 @@
+"""Simple service for building product cards."""
+from parsers._1688 import parse_1688_product
+
+
+def build_product_card(url: str) -> dict:
+    """Build a product card by fetching and parsing 1688 product data."""
+    data = parse_1688_product(url)
+    return {
+        "title": data["name"],
+        "price": data["price"],
+        "images": data["images"],
+        "delivery": data["delivery"],
+    }

--- a/tests/data/1688_product1.html
+++ b/tests/data/1688_product1.html
@@ -1,0 +1,1 @@
+<html><head><script>window.__INIT_DATA__ = {"name": "Sample Product A", "sku": {"price": "10.00"}, "images": ["a1.jpg", "a2.jpg"], "delivery": {"minOrder": 1, "shipsFrom": "China"}};</script></head><body></body></html>

--- a/tests/data/1688_product2.html
+++ b/tests/data/1688_product2.html
@@ -1,0 +1,1 @@
+<html><body><script type="text/javascript">window.__INIT_DATA__ = {"title": "Sample Product B", "price": "20.00", "gallery": ["b1.jpg"], "delivery": {"minOrder": 5, "shipsFrom": "USA"}};</script></body></html>

--- a/tests/test_parse_1688.py
+++ b/tests/test_parse_1688.py
@@ -1,0 +1,64 @@
+import pathlib
+
+import requests
+
+from parsers._1688 import parse_1688_product, ParsingError
+
+
+class DummyResponse:
+    def __init__(self, text: str, status_code: int = 200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(self.status_code)
+
+
+def fake_get_factory(text: str, status_code: int = 200):
+    def _get(url, timeout=10):
+        return DummyResponse(text, status_code)
+    return _get
+
+
+def test_parse_product_example_1(monkeypatch):
+    html = pathlib.Path("tests/data/1688_product1.html").read_text()
+    monkeypatch.setattr(requests, "get", fake_get_factory(html))
+    data = parse_1688_product("http://example.com/product1")
+    assert data["name"] == "Sample Product A"
+    assert data["price"] == "10.00"
+    assert data["images"] == ["a1.jpg", "a2.jpg"]
+    assert data["delivery"]["shipsFrom"] == "China"
+
+
+def test_parse_product_example_2(monkeypatch):
+    html = pathlib.Path("tests/data/1688_product2.html").read_text()
+    monkeypatch.setattr(requests, "get", fake_get_factory(html))
+    data = parse_1688_product("http://example.com/product2")
+    assert data["name"] == "Sample Product B"
+    assert data["price"] == "20.00"
+    assert data["images"] == ["b1.jpg"]
+    assert data["delivery"]["minOrder"] == 5
+
+
+def test_network_error(monkeypatch):
+    def _get(url, timeout=10):
+        raise requests.RequestException("boom")
+    monkeypatch.setattr(requests, "get", _get)
+    try:
+        parse_1688_product("http://example.com/error")
+    except ParsingError:
+        pass
+    else:
+        assert False, "ParsingError was not raised"
+
+
+def test_invalid_structure(monkeypatch):
+    html = "<html><body></body></html>"
+    monkeypatch.setattr(requests, "get", fake_get_factory(html))
+    try:
+        parse_1688_product("http://example.com/invalid")
+    except ParsingError:
+        pass
+    else:
+        assert False, "ParsingError was not raised for invalid HTML"


### PR DESCRIPTION
## Summary
- implement 1688 product parser that fetches page and extracts core fields
- add simple service that builds product cards using the parser
- cover parser with tests on saved HTML examples and error scenarios

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73861a61883279740cf7ae9166cb7